### PR TITLE
Handle non-integer and empty meetings

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -44,14 +44,15 @@ export namespace Team {
          *
          * @default 1
          */
-        readonly meetings?: number;
+        readonly meetings?: number | undefined;
 
         /**
-         * Throws when the team attends more than the expected number of `meetings`.
+         * Throws when the team attends more than the expected number of `meetings`,
+         * or if scheduling an empty meeting.
          *
          * @default false
          */
-        readonly strict?: boolean;
+        readonly strict?: boolean | undefined;
     }
 
     type ElementOf<T> = T extends (infer E)[] ? E : T;

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,27 +29,52 @@ exports.Team = class {
             this._reject = reject;
         });
 
-        const meetings = options.meetings || 1;
+        const meetings = options.meetings ?? 1;
+        const strict = !!options.strict;
+
+        if (!Number.isInteger(meetings) || meetings <= 0) {
+            if (meetings === 0 && !strict) {
+                return this._finalize(null, null);
+            }
+
+            throw new Error('Invalid meetings value');
+        }
+
         this.#meetings = meetings;
         this.#count = meetings;
         this.#notes = [];
         this.#done = false;
-        this.#strict = options.strict;
+        this.#strict = strict;
+
+    }
+
+    _finalize(err, note) {
+
+        this.#done = true;
+        this.#notes = null;
+
+        if (err) {
+            this._reject(err);
+        }
+        else {
+            this._resolve(note);
+        }
     }
 
     attend(note) {
 
-        if (this.#strict && this.#done) {
-            throw new Error('Unscheduled meeting');
-        }
-        else if (this.#done) {
+        if (this.#done) {
+            if (this.#strict) {
+                throw new Error('Unscheduled meeting');
+            }
+
+            // else ignore
+
             return;
         }
 
         if (note instanceof Error) {
-            this.#done = true;
-            this.#notes = null;
-            return this._reject(note);
+            return this._finalize(note);
         }
 
         this.#notes.push(note);
@@ -58,9 +83,7 @@ exports.Team = class {
             return;
         }
 
-        this.#done = true;
-        this._resolve(this.#meetings === 1 ? this.#notes[0] : [...this.#notes]);
-        this.#notes = null;
+        this._finalize(null, this.#meetings === 1 ? this.#notes[0] : this.#notes);
     }
 
     async regroup(options) {

--- a/test/index.js
+++ b/test/index.js
@@ -198,6 +198,23 @@ describe('Team', () => {
         expect(Teamwork.Team._notes(team)).to.be.null();
     });
 
+    it('immediately resolves non-strict empty meetings with null', async () => {
+
+        const team = new Teamwork.Team({ meetings: 0, strict: false });
+
+        const notes = await team.work;
+        expect(notes).to.equal(null);
+    });
+
+    it('throws error on invalid meetings', () => {
+
+        expect(() => new Teamwork.Team({ meetings: 0, strict: true })).to.throw('Invalid meetings value');
+        expect(() => new Teamwork.Team({ meetings: 0.5 })).to.throw('Invalid meetings value');
+        expect(() => new Teamwork.Team({ meetings: -1 })).to.throw('Invalid meetings value');
+        expect(() => new Teamwork.Team({ meetings: NaN })).to.throw('Invalid meetings value');
+        expect(() => new Teamwork.Team({ meetings: '' })).to.throw('Invalid meetings value');
+    });
+
     it('regroup works after team error', async () => {
 
         const team = new Teamwork.Team({ meetings: 2, strict: true });


### PR DESCRIPTION
This is a bugfix to handle weird values for meetings, that could happen in user code when it is a computed or derived value. Any value that now throws would have unexpected behaviour.

This also includes a minor new feature, which is the handling of `{ meetings: 0 }` without `strict`. In this case, it will immediately resolve the meeting with a `null` value. Previously, it would behave as `{ meetings: 1 }`, which seems quite wrong.